### PR TITLE
Fix fetch_assoc error on dashboard

### DIFF
--- a/Admin/employee-dashboard.php
+++ b/Admin/employee-dashboard.php
@@ -62,11 +62,15 @@ $resHistory = $conn->query($sqlHistory);
 $historyLabels = [];
 $historyHours = [];
 $historyAbsent = [];
-while ($row = $resHistory->fetch_assoc()) {
-    $historyLabels[] = $row['attDate'];
-    $hours = round($row['totalMinutes'] / 60, 2);
-    $historyHours[] = $hours;
-    $historyAbsent[] = (int)$row['absentCount'];
+if ($resHistory) {
+    while ($row = $resHistory->fetch_assoc()) {
+        $historyLabels[] = $row['attDate'];
+        $hours = round($row['totalMinutes'] / 60, 2);
+        $historyHours[] = $hours;
+        $historyAbsent[] = (int)$row['absentCount'];
+    }
+} else {
+    error_log('Error fetching history: ' . $conn->error);
 }
 
 $chartLabelsJson = json_encode($historyLabels);


### PR DESCRIPTION
## Summary
- avoid calling `fetch_assoc()` when employee history query fails

## Testing
- `composer install`
- `php -l Admin/employee-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_687539cf866483249b82629dcad08815