### PR TITLE
Fix Chart.js initialization timing

### DIFF
--- a/Admin/employee-dashboard.php
+++ b/Admin/employee-dashboard.php
@@ -297,32 +297,44 @@ $chartHoursJson  = json_encode($historyHours);
   
   <!-- Attendance History Chart -->
   <script>
-    const ctx = document.getElementById('attendanceChart').getContext('2d');
-    const attendanceChart = new Chart(ctx, {
-      type: 'line',
-      data: {
-        labels: <?php echo $chartLabelsJson; ?>,
-        datasets: [{
-          label: 'Working Hours',
-          data: <?php echo $chartHoursJson; ?>,
-          borderColor: 'rgba(75, 192, 192, 1)',
-          backgroundColor: 'rgba(75, 192, 192, 0.2)',
-          fill: false,
-          tension: 0.2
-        }]
-      },
-      options: {
-        responsive: true,
-        scales: { y: { beginAtZero: true } },
-        plugins: {
-          legend: { position: 'top' },
-          title: {
-            display: true,
-            text: document.querySelector('[data-key="dashboard.workingHoursChartTitle"]')?.textContent
+    function initAttendanceChart() {
+      const ctx = document.getElementById('attendanceChart').getContext('2d');
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: <?php echo $chartLabelsJson; ?>,
+          datasets: [{
+            label: 'Working Hours',
+            data: <?php echo $chartHoursJson; ?>,
+            borderColor: 'rgba(75, 192, 192, 1)',
+            backgroundColor: 'rgba(75, 192, 192, 0.2)',
+            fill: false,
+            tension: 0.2
+          }]
+        },
+        options: {
+          responsive: true,
+          scales: { y: { beginAtZero: true } },
+          plugins: {
+            legend: { position: 'top' },
+            title: {
+              display: true,
+              text: document.querySelector('[data-key="dashboard.workingHoursChartTitle"]')?.textContent
+            }
           }
         }
+      });
+    }
+
+    function waitForChartJs() {
+      if (window.Chart) {
+        initAttendanceChart();
+      } else {
+        setTimeout(waitForChartJs, 50);
       }
-    });
+    }
+
+    waitForChartJs();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wait for Chart.js to load before initializing chart on employee dashboard

## Testing
- `php -l Admin/employee-dashboard.php`

------
https://chatgpt.com/codex/tasks/task_e_68761829c5108324888ccc338fbe87c2