### PR TITLE
Fix DataTables initialization by removing extra jQuery

### DIFF
--- a/Admin/current-orders.php
+++ b/Admin/current-orders.php
@@ -117,8 +117,6 @@ if (!isset($_SESSION['UserId'])) {
     <!-- =================================
          JS Libraries in correct order
          ================================= -->
-    <!-- jQuery first -->
-    <script src="assets/js/jquery-3.7.1.min.js"></script>
     <!-- DataTables JS -->
     <!-- DataTables Buttons and Print extension -->
     <!-- Bootstrap Bundle -->

--- a/Admin/customer_dashboard.php
+++ b/Admin/customer_dashboard.php
@@ -194,7 +194,6 @@ if (!isset($_SESSION['UserId'])) {
     <?php include_once './footer.php'; ?>
 
     <!-- JS Libraries -->
-    <script src="assets/js/jquery-3.7.1.min.js"></script>
     <script src="assets/vendor/DataTables/jquery.dataTables.min.js"></script>
     <script src="assets/vendor/DataTables/dataTables.buttons.min.js"></script>
     <script src="assets/vendor/DataTables/buttons.html5.min.js"></script>

--- a/Admin/feedback.php
+++ b/Admin/feedback.php
@@ -18,8 +18,6 @@ if (!isset($_SESSION['UserId'])) {
   <!-- DataTables CSS -->
   <!-- SweetAlert2 CSS -->
 
-  <!-- jQuery -->
-  <script src="assets/js/jquery-3.7.1.min.js"></script>
   <!-- DataTables JS -->
   <!-- Bootstrap JS -->
   <!-- SweetAlert2 JS -->

--- a/Admin/inventory.php
+++ b/Admin/inventory.php
@@ -234,8 +234,6 @@ if (!isset($_SESSION['UserId'])) {
     <!-- Include Footer -->
     <?php include_once './footer.php'; ?>
 
-    <!-- jQuery -->
-    <script src="assets/js/jquery-3.7.1.min.js"></script>
     <!-- Bootstrap JS -->
     <script src="assets/vendor/bootstrap/5.3.0/bootstrap.bundle.min.js"></script>
     <!-- DataTables JS -->

--- a/Admin/kot-history.php
+++ b/Admin/kot-history.php
@@ -13,8 +13,6 @@ require_once 'connection.php';
   <!-- DataTables CSS -->
   <!-- Bootstrap CSS -->
 
-  <!-- jQuery -->
-  <script src="assets/js/jquery-3.7.1.min.js"></script>
   <!-- DataTables JS -->
   <!-- Bootstrap JS -->
 

--- a/Admin/users_dashboard.php
+++ b/Admin/users_dashboard.php
@@ -153,9 +153,8 @@ if (!isset($_SESSION['UserId'])) {
 
     <!-- ======================================
          JS Libraries: jQuery, DataTables, Buttons, Bootstrap
-         (Ensure jQuery and DataTables load before your initialization code)
-         ====================================== -->
-    <script src="assets/js/jquery-3.7.1.min.js"></script>
+        (Ensure jQuery and DataTables load before your initialization code)
+        ====================================== -->
     <!-- Include the print button extension -->
 
     <script>


### PR DESCRIPTION
## Summary
- remove redundant jQuery script tags so DataTables uses the correct jQuery instance

## Testing
- `php -l Admin/current-orders.php`
- `php -l Admin/customer_dashboard.php`
- `php -l Admin/feedback.php`
- `php -l Admin/inventory.php`
- `php -l Admin/kot-history.php`
- `php -l Admin/users_dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68761c3222608324b1add87ca3987db4