### PR TITLE
Fix dropdown signout issue

### DIFF
--- a/Admin/navbar.php
+++ b/Admin/navbar.php
@@ -29,9 +29,8 @@
       </li><!-- Fin Notification Nav -->
 
       <!-- Profile Nav -->
-      <li class="nav-item dropdown">
-        <?php include_once './profil/profil_nav.php'; ?>
-      </li><!-- Fin Profile Nav -->
+      <?php include_once './profil/profil_nav.php'; ?>
+      <!-- Fin Profile Nav -->
     </ul>
   </nav><!-- Fin barre d’icônes -->
 </header>


### PR DESCRIPTION
## Summary
- remove extra nested `<li>` around profile dropdown

## Testing
- `php -l Admin/navbar.php`


------
https://chatgpt.com/codex/tasks/task_e_68761fb7ef8883249134b27d99205507