### PR TITLE
Fix storekeeper dashboard access

### DIFF
--- a/Admin/sidebar.php
+++ b/Admin/sidebar.php
@@ -7,7 +7,7 @@ if($_SESSION['privilege']=='Manager'){
 else if($_SESSION['privilege']=='Boss'){
     include_once './sidebarboss.php';
 }
-else if($_SESSION['privilege']=='Stock'){
+else if($_SESSION['privilege']=='Storekeeper'){
     include_once './sidebarstock.php';
 }
 else{
@@ -15,4 +15,4 @@ else{
 }
 
 ?>
-<!-- End Sidebar --> "
+<!-- End Sidebar -->

--- a/Admin/stock-dashboard.php
+++ b/Admin/stock-dashboard.php
@@ -3,7 +3,7 @@ session_start();
 require_once 'connection.php';
 require_once __DIR__ . '/../includes/auth.php';
 
-require_privilege(['Stock']);
+require_privilege(['Storekeeper']);
 ?>
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary
- show stock sidebar for the `Storekeeper` privilege
- allow `Storekeeper` role to access `stock-dashboard.php`

## Testing
- `php -l Admin/sidebar.php`
- `php -l Admin/stock-dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68763ad0b84083249e5807a7aa247372