### PR TITLE
Fix receipt centering

### DIFF
--- a/Admin/pos.php
+++ b/Admin/pos.php
@@ -34,7 +34,7 @@ require_privilege(['Boss','Manager','User']);
    /* Receipt styling for printing */
     #receiptContent {
       display: none; /* Hidden by default */
-      width: 200px; /* Width optimized for Epson TM-T20 */
+      width: 280px; /* Width optimized for Epson TM-T20 80mm */
       margin: 0 auto; /* Changed from '0 0 0 10px' to '0 auto' for proper centering */
       padding: 0;
       font-family: Arial, sans-serif;
@@ -1092,9 +1092,9 @@ $("#confirmSale").on("click", async function() {
           @page { margin: 0; }
           body { margin: 0; padding: 0; }
           #receiptContent {
-            margin: 0 0 0 10px; /* Added 10px left margin */
+            margin: 0 auto; /* Center content for thermal printer */
             padding: 0;
-            width: 200px; /* Reduced to fit with margin */
+            width: 280px; /* Width optimized for Epson TM-T20 80mm */
             font-family: Arial, sans-serif;
             text-align: center;
             font-size: 12px;
@@ -1174,7 +1174,8 @@ $("#confirmSale").on("click", async function() {
                     width: 100%;
                   }
                   .receipt-section {
-                    margin: 0 auto; /* Changed from '0 0 0 10px' to '0 auto' for proper centering */
+                    margin: 0 auto; /* Center each section */
+                    width: 280px; /* Match Epson TM-T20 paper */
                     padding: 0 0 20px 0;
                     font-family: Arial, sans-serif;
                     text-align: center;


### PR DESCRIPTION
## Summary
- center receipt content when printing from POS
- adjust width for Epson TM-T20 paper

## Testing
- `php -l Admin/pos.php`


------
https://chatgpt.com/codex/tasks/task_e_6876520a6e6c8324b2e46bbfe638841a