### PR TITLE
Fix print error by adding fallback printer

### DIFF
--- a/Admin/pos.php
+++ b/Admin/pos.php
@@ -290,6 +290,40 @@ require_privilege(['Boss','Manager','User']);
 
 <!-- Hidden receipt for printing -->
 <div id="receiptContent"></div>
+
+<!-- Fallback printer implementation -->
+<script>
+  if (!window.printer) {
+    window.printer = {
+      printHTML: async function(html) {
+        return new Promise(resolve => {
+          const w = window.open('', '_blank');
+          w.document.write(html);
+          w.document.close();
+          w.focus();
+          w.print();
+          w.close();
+          resolve();
+        });
+      },
+      getLogoBase64: async function() {
+        try {
+          const resp = await fetch('../LogoMaza.png');
+          const blob = await resp.blob();
+          return await new Promise((res, rej) => {
+            const reader = new FileReader();
+            reader.onloadend = () => res(reader.result);
+            reader.onerror = rej;
+            reader.readAsDataURL(blob);
+          });
+        } catch (e) {
+          console.error('Failed to load logo:', e);
+          return '';
+        }
+      }
+    };
+  }
+</script>
   <?php include_once './footer.php'; ?>
 
 <script>


### PR DESCRIPTION
## Summary
- add a browser-based printer fallback in `pos.php`

## Testing
- `composer validate --no-check-publish`
- `php -l Admin/pos.php`


------
https://chatgpt.com/codex/tasks/task_e_68767fb55a28832487b4799f1ac4eaea