### PR TITLE
Fix receipt printing details

### DIFF
--- a/Admin/pos.php
+++ b/Admin/pos.php
@@ -1111,7 +1111,12 @@ $("#confirmSale").on("click", async function() {
       $("#receiptContent #receiptLogo").remove(); // Remove logo on error
     }
 
-    // Get final content after logo setup
+    // Append the preview details without its header
+    const previewClone = $("#previewContent").clone();
+    previewClone.find('.text-center.mb-4').remove();
+    $("#receiptContent").append(previewClone.html());
+
+    // Get final content after adding details and logo
     const finalContent = $("#receiptContent").html();
 // Print HTML
     const html = `


### PR DESCRIPTION
## Summary
- include previewed purchase details in the printed receipt

## Testing
- `php -l Admin/pos.php`
- `find . -name '*.php' | xargs -n1 php -l` *(fails: `fix_discount_buffet.php` parse error)*

------
https://chatgpt.com/codex/tasks/task_e_6876896aa45083249323eb79f4bc9cd0